### PR TITLE
Add the HSV colorspace

### DIFF
--- a/lib/chameleon/hsv.ex
+++ b/lib/chameleon/hsv.ex
@@ -1,0 +1,101 @@
+defmodule Chameleon.HSV do
+  @enforce_keys [:h, :s, :v]
+  defstruct @enforce_keys
+
+  @moduledoc """
+  HSV (hue, saturation, value) represents colors using a cylinder where colors
+  are sorted by angles and then adjusted via the saturation and value
+  parameters.
+
+  See Chameleon.HSL for a related, but different colorspace.
+  """
+
+  @type degrees() :: 0..360
+  @type percent() :: 0..100
+
+  @type t() :: %__MODULE__{h: degrees(), s: percent(), v: percent()}
+
+  @doc """
+  Create a new HSV color.
+  """
+  def new(h, s, v), do: %__MODULE__{h: h, s: s, v: v}
+end
+
+defmodule Chameleon.HSV.Chameleon.RGB do
+  defstruct [:from]
+
+  alias Chameleon.RGB
+
+  @moduledoc false
+
+  defimpl Chameleon.Color do
+    def convert(%{from: hsv}) do
+      hsv_to_rgb(hsv.h, hsv.s, hsv.v)
+    end
+
+    defp hsv_to_rgb(_h, s, v) when s <= 0 do
+      a = round(255 * v / 100)
+      RGB.new(a, a, a)
+    end
+
+    defp hsv_to_rgb(h, s, v) do
+      h_sixths = h / 60
+      h_sector = round(:math.floor(h_sixths))
+      h_offset = h_sixths - h_sector
+
+      s = s / 100
+      v = v / 100
+
+      x = round(255 * v * (1 - s))
+      y = round(255 * v * (1 - s * h_offset))
+      z = round(255 * v * (1 - s * (1 - h_offset)))
+      w = round(255 * v)
+
+      hsv_sector_to_rgb(h_sector, x, y, z, w)
+    end
+
+    defp hsv_sector_to_rgb(0, x, _y, z, w), do: RGB.new(w, z, x)
+    defp hsv_sector_to_rgb(1, x, y, _z, w), do: RGB.new(y, w, x)
+    defp hsv_sector_to_rgb(2, x, _y, z, w), do: RGB.new(x, w, z)
+    defp hsv_sector_to_rgb(3, x, y, _z, w), do: RGB.new(x, y, w)
+    defp hsv_sector_to_rgb(4, x, _y, z, w), do: RGB.new(z, x, w)
+    defp hsv_sector_to_rgb(5, x, y, _z, w), do: RGB.new(w, x, y)
+  end
+end
+
+defmodule Chameleon.RGB.Chameleon.HSV do
+  defstruct [:from]
+
+  alias Chameleon.HSV
+
+  @moduledoc false
+
+  defimpl Chameleon.Color do
+    def convert(%{from: rgb}) do
+      r = rgb.r / 255
+      g = rgb.g / 255
+      b = rgb.b / 255
+
+      c_max = max(r, max(g, b))
+      c_min = min(r, min(g, b))
+      delta = c_max - c_min
+
+      h = hue(delta, c_max, r, g, b) |> normalize_degrees() |> round()
+      s = round(saturation(delta, c_max) * 100)
+      v = round(c_max * 100)
+
+      HSV.new(h, s, v)
+    end
+
+    defp hue(delta, _, _, _, _) when delta <= 0, do: 0
+    defp hue(delta, r, r, g, b), do: 60 * rem(round((g - b) / delta), 6)
+    defp hue(delta, g, r, g, b), do: 60 * ((b - r) / delta + 2)
+    defp hue(delta, b, r, g, b), do: 60 * ((r - g) / delta + 4)
+
+    defp saturation(_delta, c_max) when c_max <= 0, do: 0
+    defp saturation(delta, c_max), do: delta / c_max
+
+    defp normalize_degrees(degrees) when degrees < 0, do: degrees + 360
+    defp normalize_degrees(degrees), do: degrees
+  end
+end

--- a/test/hsv_test.exs
+++ b/test/hsv_test.exs
@@ -1,0 +1,47 @@
+defmodule HSVTest do
+  use ExUnit.Case
+  alias Chameleon.{RGB, HSV}
+
+  doctest Chameleon.HSV
+
+  def rgb_to_hsv_pairs() do
+    [
+      {RGB.new(0, 0, 0), HSV.new(0, 0, 0)},
+      {RGB.new(255, 255, 255), HSV.new(0, 0, 100)},
+      {RGB.new(255, 0, 0), HSV.new(0, 100, 100)},
+      {RGB.new(0, 255, 0), HSV.new(120, 100, 100)},
+      {RGB.new(0, 0, 255), HSV.new(240, 100, 100)},
+      {RGB.new(255, 255, 0), HSV.new(60, 100, 100)},
+      {RGB.new(0, 255, 255), HSV.new(180, 100, 100)},
+      {RGB.new(255, 0, 255), HSV.new(300, 100, 100)},
+      {RGB.new(191, 191, 191), HSV.new(0, 0, 75)},
+      {RGB.new(128, 128, 128), HSV.new(0, 0, 50)},
+      {RGB.new(128, 0, 0), HSV.new(0, 100, 50)},
+      {RGB.new(128, 128, 0), HSV.new(60, 100, 50)},
+      {RGB.new(0, 128, 0), HSV.new(120, 100, 50)},
+      {RGB.new(128, 0, 128), HSV.new(300, 100, 50)},
+      {RGB.new(0, 128, 128), HSV.new(180, 100, 50)},
+      {RGB.new(0, 0, 128), HSV.new(240, 100, 50)}
+    ]
+  end
+
+  test "converts from HSV to RGB" do
+    for {rgb, hsv} <- rgb_to_hsv_pairs() do
+      assert rgb == Chameleon.convert(hsv, RGB)
+    end
+  end
+
+  test "converts from RGB to HSV" do
+    for {rgb, hsv} <- rgb_to_hsv_pairs() do
+      assert hsv == Chameleon.convert(rgb, HSV)
+    end
+  end
+
+  test "converts from keyword to HSV" do
+    # Fails since "black" isn't RGB 0, 0, 0
+    # assert HSV.new(0, 0, 0) == Chameleon.convert("black", HSV)
+    assert HSV.new(0, 100, 100) == Chameleon.convert("red", HSV)
+    assert HSV.new(120, 100, 100) == Chameleon.convert("lime", HSV)
+    assert HSV.new(240, 100, 100) == Chameleon.convert("blue", HSV)
+  end
+end


### PR DESCRIPTION
This adds the HSV colorspace. I had mistakenly thought that HSL would be close enough, but that didn't work out.

A few notes on this PR. I think these are all food for thought or for future PRs:

1. I added the `percent()` and `angle()` types for this module. They probably should be refactored to a common location when they get used by other modules.
2. I wonder if floating point values should be allowed. I didn't make this change since it would be inconsistent with other colors, but the restriction to use integers felt arbitrary.
3. I separated out the HSV tests from the others since I wanted to unit test it against more colors and it felt too much for one test file. I think it would be nice to have a `_test.exs` for each supported color.
4. I found out that "black" converts using Pantone black which is not RGB(0, 0, 0). I found this surprising. Since I don't use Pantone colors, I wasn't sure whether you'd find this surprising so I just commented out the test.

