### PR TITLE
Add @moduledoc false for the conversions

### DIFF
--- a/lib/chameleon/cmyk.ex
+++ b/lib/chameleon/cmyk.ex
@@ -1,6 +1,8 @@
 defmodule Chameleon.CMYK.Chameleon.Hex do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: cmyk}) do
       Chameleon.CMYK.to_hex(cmyk)
@@ -10,6 +12,8 @@ end
 
 defmodule Chameleon.CMYK.Chameleon.RGB do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: cmyk}) do
@@ -21,6 +25,8 @@ end
 defmodule Chameleon.CMYK.Chameleon.HSL do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: cmyk}) do
       Chameleon.CMYK.to_hsl(cmyk)
@@ -31,6 +37,8 @@ end
 defmodule Chameleon.CMYK.Chameleon.Keyword do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: cmyk}) do
       Chameleon.CMYK.to_keyword(cmyk)
@@ -40,6 +48,8 @@ end
 
 defmodule Chameleon.CMYK.Chameleon.Pantone do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: cmyk}) do

--- a/lib/chameleon/hex.ex
+++ b/lib/chameleon/hex.ex
@@ -1,6 +1,8 @@
 defmodule Chameleon.Hex.Chameleon.RGB do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: hex}) do
       Chameleon.Hex.to_rgb(hex)
@@ -10,6 +12,8 @@ end
 
 defmodule Chameleon.Hex.Chameleon.CMYK do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: hex}) do
@@ -21,6 +25,8 @@ end
 defmodule Chameleon.Hex.Chameleon.HSL do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: hex}) do
       Chameleon.Hex.to_hsl(hex)
@@ -31,6 +37,8 @@ end
 defmodule Chameleon.Hex.Chameleon.Keyword do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: hex}) do
       Chameleon.Hex.to_keyword(hex)
@@ -40,6 +48,8 @@ end
 
 defmodule Chameleon.Hex.Chameleon.Pantone do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: hex}) do

--- a/lib/chameleon/hsl.ex
+++ b/lib/chameleon/hsl.ex
@@ -1,6 +1,8 @@
 defmodule Chameleon.HSL.Chameleon.Hex do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: hsl}) do
       Chameleon.HSL.to_hex(hsl)
@@ -10,6 +12,8 @@ end
 
 defmodule Chameleon.HSL.Chameleon.CMYK do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: hsl}) do
@@ -21,6 +25,8 @@ end
 defmodule Chameleon.HSL.Chameleon.RGB do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: hsl}) do
       Chameleon.HSL.to_rgb(hsl)
@@ -31,6 +37,8 @@ end
 defmodule Chameleon.HSL.Chameleon.Keyword do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: hsl}) do
       Chameleon.HSL.to_keyword(hsl)
@@ -40,6 +48,8 @@ end
 
 defmodule Chameleon.HSL.Chameleon.Pantone do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: hsl}) do

--- a/lib/chameleon/keyword.ex
+++ b/lib/chameleon/keyword.ex
@@ -1,6 +1,8 @@
 defmodule Chameleon.Keyword.Chameleon.Hex do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: keyword}) do
       Chameleon.Keyword.to_hex(keyword)
@@ -10,6 +12,8 @@ end
 
 defmodule Chameleon.Keyword.Chameleon.CMYK do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: keyword}) do
@@ -21,6 +25,8 @@ end
 defmodule Chameleon.Keyword.Chameleon.HSL do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: keyword}) do
       Chameleon.Keyword.to_hsl(keyword)
@@ -31,6 +37,8 @@ end
 defmodule Chameleon.Keyword.Chameleon.RGB do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: keyword}) do
       Chameleon.Keyword.to_rgb(keyword)
@@ -40,6 +48,8 @@ end
 
 defmodule Chameleon.Keyword.Chameleon.Pantone do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: keyword}) do

--- a/lib/chameleon/keyword_to_hex.ex
+++ b/lib/chameleon/keyword_to_hex.ex
@@ -1,4 +1,5 @@
 defmodule Chameleon.KeywordToHex do
+  @moduledoc false
   @map %{
     "pink" => "ffc0cb",
     "lightpink" => "ffb6c1",

--- a/lib/chameleon/keyword_to_rgb.ex
+++ b/lib/chameleon/keyword_to_rgb.ex
@@ -1,4 +1,5 @@
 defmodule Chameleon.KeywordToRGB do
+  @moduledoc false
   @map %{
     "aliceblue" => [240, 248, 255],
     "antiquewhite" => [250, 235, 215],

--- a/lib/chameleon/pantone.ex
+++ b/lib/chameleon/pantone.ex
@@ -1,6 +1,8 @@
 defmodule Chameleon.Pantone.Chameleon.Hex do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: pantone}) do
       Chameleon.Pantone.to_hex(pantone)
@@ -10,6 +12,8 @@ end
 
 defmodule Chameleon.Pantone.Chameleon.CMYK do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: pantone}) do
@@ -21,6 +25,8 @@ end
 defmodule Chameleon.Pantone.Chameleon.HSL do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: pantone}) do
       Chameleon.Pantone.to_hsl(pantone)
@@ -31,6 +37,8 @@ end
 defmodule Chameleon.Pantone.Chameleon.Keyword do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: pantone}) do
       Chameleon.Pantone.to_keyword(pantone)
@@ -40,6 +48,8 @@ end
 
 defmodule Chameleon.Pantone.Chameleon.RGB do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: pantone}) do

--- a/lib/chameleon/pantone_to_hex.ex
+++ b/lib/chameleon/pantone_to_hex.ex
@@ -1,4 +1,5 @@
 defmodule Chameleon.PantoneToHex do
+  @moduledoc false
   @map %{
     "100" => "F3ED86",
     "101" => "F5EC62",

--- a/lib/chameleon/rgb.ex
+++ b/lib/chameleon/rgb.ex
@@ -1,6 +1,8 @@
 defmodule Chameleon.RGB.Chameleon.Hex do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: rgb}) do
       Chameleon.RGB.to_hex(rgb)
@@ -10,6 +12,8 @@ end
 
 defmodule Chameleon.RGB.Chameleon.CMYK do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: rgb}) do
@@ -21,6 +25,8 @@ end
 defmodule Chameleon.RGB.Chameleon.HSL do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: rgb}) do
       Chameleon.RGB.to_hsl(rgb)
@@ -31,6 +37,8 @@ end
 defmodule Chameleon.RGB.Chameleon.Keyword do
   defstruct [:from]
 
+  @moduledoc false
+
   defimpl Chameleon.Color do
     def convert(%{from: rgb}) do
       Chameleon.RGB.to_keyword(rgb)
@@ -40,6 +48,8 @@ end
 
 defmodule Chameleon.RGB.Chameleon.Pantone do
   defstruct [:from]
+
+  @moduledoc false
 
   defimpl Chameleon.Color do
     def convert(%{from: rgb}) do


### PR DESCRIPTION
The color conversion modules really clutter up the documentation and
aren't directly callable by the user anyway. This removes them from the
list so it's easier to find colors in the module index.