### PR TITLE
Remove unnecessary calls to Float.round

### DIFF
--- a/lib/chameleon/cmyk.ex
+++ b/lib/chameleon/cmyk.ex
@@ -29,9 +29,9 @@ defmodule Chameleon.CMYK do
   def to_rgb(cmyk) do
     [c, m, y, k] = Enum.map([cmyk.c, cmyk.m, cmyk.y, cmyk.k], fn v -> v / 100.0 end)
 
-    r = round(Float.round(255.0 * (1.0 - c) * (1.0 - k)))
-    g = round(Float.round(255.0 * (1.0 - m) * (1.0 - k)))
-    b = round(Float.round(255.0 * (1.0 - y) * (1.0 - k)))
+    r = round(255.0 * (1.0 - c) * (1.0 - k))
+    g = round(255.0 * (1.0 - m) * (1.0 - k))
+    b = round(255.0 * (1.0 - y) * (1.0 - k))
 
     Chameleon.RGB.new(r, g, b)
   end

--- a/lib/chameleon/rgb.ex
+++ b/lib/chameleon/rgb.ex
@@ -179,28 +179,24 @@ defmodule Chameleon.RGB do
   defp calculate_hue(delta, rgb_max, rgb) do
     [r, g, b] = rgb
 
-    h =
-      cond do
-        rgb_max == r ->
-          offset = if g < b, do: 6, else: 0
-          60.0 * ((g - b) / delta + offset)
+    cond do
+      rgb_max == r ->
+        offset = if g < b, do: 6, else: 0
+        60.0 * ((g - b) / delta + offset)
 
-        rgb_max == g ->
-          60.0 * ((b - r) / delta + 2)
+      rgb_max == g ->
+        60.0 * ((b - r) / delta + 2)
 
-        rgb_max == b ->
-          60.0 * ((r - g) / delta + 4)
+      rgb_max == b ->
+        60.0 * ((r - g) / delta + 4)
 
-        true ->
-          0
-      end
-
-    Float.round(h)
+      true ->
+        0
+    end
   end
 
   defp calculate_lightness(rgb_max, rgb_min) do
-    ((rgb_max + rgb_min) / 2 * 100)
-    |> Float.round()
+    (rgb_max + rgb_min) / 2 * 100
   end
 
   defp calculate_saturation(rgb_max, rgb_min) when rgb_max - rgb_min == 0, do: 0


### PR DESCRIPTION
In each of these cases, Float.round/2 was immediately followed by a call
to round/1. Since both calls were rounding to the nearest integer
Float.round/2 wasn't needed.