### PR TITLE
Update specs for new() to accept non_neg_integer

### DIFF
--- a/lib/chameleon/cmyk.ex
+++ b/lib/chameleon/cmyk.ex
@@ -13,7 +13,8 @@ defmodule Chameleon.CMYK do
       iex> _cmyk = Chameleon.CMYK.new(25, 30, 80, 0)
       %Chameleon.CMYK{c: 25, m: 30, y: 80, k: 0}
   """
-  @spec new(pos_integer(), pos_integer(), pos_integer(), pos_integer()) :: Chameleon.CMYK.t()
+  @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          Chameleon.CMYK.t()
   def new(c, m, y, k), do: %__MODULE__{c: c, m: m, y: y, k: k}
 
   defimpl Chameleon.Color.RGB do

--- a/lib/chameleon/hsl.ex
+++ b/lib/chameleon/hsl.ex
@@ -13,7 +13,7 @@ defmodule Chameleon.HSL do
       iex> _hsl = Chameleon.HSL.new(7, 8, 9)
       %Chameleon.HSL{h: 7, s: 8, l: 9}
   """
-  @spec new(pos_integer(), pos_integer(), pos_integer()) :: Chameleon.HSL.t()
+  @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: Chameleon.HSL.t()
   def new(h, s, l), do: %__MODULE__{h: h, s: s, l: l}
 
   defimpl Chameleon.Color.RGB do

--- a/lib/chameleon/hsv.ex
+++ b/lib/chameleon/hsv.ex
@@ -22,7 +22,7 @@ defmodule Chameleon.HSV do
       iex> _hsv = Chameleon.HSV.new(7, 8, 9)
       %Chameleon.HSV{h: 7, s: 8, v: 9}
   """
-  @spec new(pos_integer(), pos_integer(), pos_integer()) :: Chameleon.HSV.t()
+  @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: Chameleon.HSV.t()
   def new(h, s, v), do: %__MODULE__{h: h, s: s, v: v}
 
   defimpl Chameleon.Color.RGB do

--- a/lib/chameleon/rgb.ex
+++ b/lib/chameleon/rgb.ex
@@ -13,7 +13,7 @@ defmodule Chameleon.RGB do
       iex> _rgb = Chameleon.RGB.new(25, 30, 80)
       %Chameleon.RGB{r: 25, g: 30, b: 80}
   """
-  @spec new(pos_integer(), pos_integer(), pos_integer()) :: Chameleon.RGB.t()
+  @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: Chameleon.RGB.t()
   def new(r, g, b), do: %__MODULE__{r: r, g: g, b: b}
 
   defimpl Chameleon.Color.RGB do


### PR DESCRIPTION
This PR updates the specs for the `new()` functions to resolve the following dialyzer error I ran into when integrating with Chameleon:

```text
The function call will not succeed.

Chameleon.HSV.new(0, 0, 0)

breaks the contract
(pos_integer(), pos_integer(), pos_integer()) :: t()
```

The issue is that I was trying to initialize the color black with `Chameleon.HSV.new(0, 0, 0)`, but it was failing the dialyzer check due to `0` being "not positive". Therefore I've updated all of the `pos_integer` specs to `non_neg_integer` to be able to account for `0` as a valid number that can be passed to `new()`.