### PR TITLE
Support rgb888

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ erl_crash.dump
 *.ez
 
 .DS_Store
+
+.tool-versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-elixir 1.6.4
+elixir 1.10.4-otp-23
+erlang 23.0-rc3

--- a/lib/chameleon/color.ex
+++ b/lib/chameleon/color.ex
@@ -8,7 +8,8 @@ for protocol <- [
       Chameleon.Color.HSL,
       Chameleon.Color.HSV,
       Chameleon.Color.Keyword,
-      Chameleon.Color.Pantone
+      Chameleon.Color.Pantone,
+      Chameleon.Color.RGB8
     ] do
   defprotocol protocol do
     @fallback_to_any true

--- a/lib/chameleon/color.ex
+++ b/lib/chameleon/color.ex
@@ -9,7 +9,7 @@ for protocol <- [
       Chameleon.Color.HSV,
       Chameleon.Color.Keyword,
       Chameleon.Color.Pantone,
-      Chameleon.Color.RGB8
+      Chameleon.Color.RGB888
     ] do
   defprotocol protocol do
     @fallback_to_any true

--- a/lib/chameleon/rgb.ex
+++ b/lib/chameleon/rgb.ex
@@ -20,8 +20,8 @@ defmodule Chameleon.RGB do
     def from(rgb), do: rgb
   end
 
-  defimpl Chameleon.Color.RGB8 do
-    def from(rgb), do: RGB.to_rgb8(rgb)
+  defimpl Chameleon.Color.RGB888 do
+    def from(rgb), do: RGB.to_rgb888(rgb)
   end
 
   defimpl Chameleon.Color.CMYK do
@@ -51,9 +51,9 @@ defmodule Chameleon.RGB do
   #### / Conversion Functions / ########################################
 
   @doc false
-  @spec to_rgb8(Chameleon.RGB.t()) :: Chameleon.RGB8.t() | {:error, String.t()}
-  def to_rgb8(rgb) do
-    Chameleon.RGB8.new(rgb.r, rgb.g, rgb.b)
+  @spec to_rgb888(Chameleon.RGB.t()) :: Chameleon.RGB888.t() | {:error, String.t()}
+  def to_rgb888(rgb) do
+    Chameleon.RGB888.new(rgb.r, rgb.g, rgb.b)
   end
 
   @doc false

--- a/lib/chameleon/rgb.ex
+++ b/lib/chameleon/rgb.ex
@@ -20,6 +20,10 @@ defmodule Chameleon.RGB do
     def from(rgb), do: rgb
   end
 
+  defimpl Chameleon.Color.RGB8 do
+    def from(rgb), do: RGB.to_rgb8(rgb)
+  end
+
   defimpl Chameleon.Color.CMYK do
     def from(rgb), do: RGB.to_cmyk(rgb)
   end
@@ -45,6 +49,12 @@ defmodule Chameleon.RGB do
   end
 
   #### / Conversion Functions / ########################################
+
+  @doc false
+  @spec to_rgb8(Chameleon.RGB.t()) :: Chameleon.RGB8.t() | {:error, String.t()}
+  def to_rgb8(rgb) do
+    Chameleon.RGB8.new(rgb.r, rgb.g, rgb.b)
+  end
 
   @doc false
   @spec to_hex(Chameleon.RGB.t()) :: Chameleon.Hex.t() | {:error, String.t()}

--- a/lib/chameleon/rgb8.ex
+++ b/lib/chameleon/rgb8.ex
@@ -1,5 +1,5 @@
-defmodule Chameleon.RGB8 do
-  alias Chameleon.RGB8
+defmodule Chameleon.RGB888 do
+  alias Chameleon.RGB888
 
   @enforce_keys [:r, :g, :b]
   defstruct @enforce_keys
@@ -10,21 +10,21 @@ defmodule Chameleon.RGB8 do
   Creates a new color struct.
 
   ## Examples
-      iex> _rgb8 = Chameleon.RGB8.new(25, 30, 80)
-      %Chameleon.RGB8{r: 25, g: 30, b: 80}
+      iex> _rgb888 = Chameleon.RGB888.new(25, 30, 80)
+      %Chameleon.RGB888{r: 25, g: 30, b: 80}
   """
   @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
-          Chameleon.RGB8.t()
+          Chameleon.RGB888.t()
   def new(r, g, b), do: %__MODULE__{r: r, g: g, b: b}
 
   defimpl Chameleon.Color.RGB do
-    def from(rgb8), do: RGB8.to_rgb(rgb8)
+    def from(rgb888), do: RGB888.to_rgb(rgb888)
   end
 
   #### / Conversion Functions / ########################################
 
   @doc false
-  @spec to_rgb(Chameleon.RGB8.t()) :: Chameleon.RGB.t() | {:error, String.t()}
+  @spec to_rgb(Chameleon.RGB888.t()) :: Chameleon.RGB.t() | {:error, String.t()}
   def to_rgb(%{r: r, g: g, b: b}) do
     Chameleon.RGB.new(r, g, b)
   end

--- a/lib/chameleon/rgb8.ex
+++ b/lib/chameleon/rgb8.ex
@@ -1,0 +1,31 @@
+defmodule Chameleon.RGB8 do
+  alias Chameleon.RGB8
+
+  @enforce_keys [:r, :g, :b]
+  defstruct @enforce_keys
+
+  @type t() :: %__MODULE__{r: integer(), g: integer(), b: integer()}
+
+  @doc """
+  Creates a new color struct.
+
+  ## Examples
+      iex> _rgb8 = Chameleon.RGB8.new(25, 30, 80)
+      %Chameleon.RGB8{r: 25, g: 30, b: 80}
+  """
+  @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+          Chameleon.RGB8.t()
+  def new(r, g, b), do: %__MODULE__{r: r, g: g, b: b}
+
+  defimpl Chameleon.Color.RGB do
+    def from(rgb8), do: RGB8.to_rgb(rgb8)
+  end
+
+  #### / Conversion Functions / ########################################
+
+  @doc false
+  @spec to_rgb(Chameleon.RGB8.t()) :: Chameleon.RGB.t() | {:error, String.t()}
+  def to_rgb(%{r: r, g: g, b: b}) do
+    Chameleon.RGB.new(r, g, b)
+  end
+end

--- a/test/rgb8_test.exs
+++ b/test/rgb8_test.exs
@@ -1,77 +1,77 @@
-defmodule RGB8Test do
+defmodule RGB888Test do
   use ExUnit.Case
   use ChameleonTest.Case
 
-  alias Chameleon.{Color, Hex, HSL, HSV, Keyword, Pantone, RGB, RGB8}
+  alias Chameleon.{Color, Hex, HSL, HSV, Keyword, Pantone, RGB, RGB888}
 
-  doctest Chameleon.RGB8
+  doctest Chameleon.RGB888
 
-  describe "RGB and RGB8 conversions" do
-    test "converts from RGB to RGB8" do
+  describe "RGB and RGB888 conversions" do
+    test "converts from RGB to RGB888" do
       for %{rgb: [r, g, b]} <- color_table() do
-        assert RGB8.new(r, g, b) == Chameleon.convert(RGB.new(r, g, b), Color.RGB8)
+        assert RGB888.new(r, g, b) == Chameleon.convert(RGB.new(r, g, b), Color.RGB888)
       end
     end
 
-    test "converts from RGB8 to RGB" do
+    test "converts from RGB888 to RGB" do
       for %{rgb: [r, g, b]} <- color_table() do
-        assert RGB.new(r, g, b) == Chameleon.convert(RGB8.new(r, g, b), Color.RGB)
+        assert RGB.new(r, g, b) == Chameleon.convert(RGB888.new(r, g, b), Color.RGB)
       end
     end
   end
 
-  describe "Hex and RGB8 conversions" do
-    test "converts from HEX to RGB8" do
+  describe "Hex and RGB888 conversions" do
+    test "converts from HEX to RGB888" do
       for %{hex: hex, rgb: [r, g, b]} <- color_table() do
-        assert RGB8.new(r, g, b) == Chameleon.convert(Hex.new(hex), Color.RGB8)
+        assert RGB888.new(r, g, b) == Chameleon.convert(Hex.new(hex), Color.RGB888)
       end
     end
 
-    test "converts from RGB8 to HEX" do
+    test "converts from RGB888 to HEX" do
       for %{hex: hex, rgb: [r, g, b]} <- color_table() do
-        assert Hex.new(hex) == Chameleon.convert(RGB8.new(r, g, b), Color.Hex)
+        assert Hex.new(hex) == Chameleon.convert(RGB888.new(r, g, b), Color.Hex)
       end
     end
   end
 
-  describe "HSL and RGB8 conversions" do
-    test "converts from HSL to RGB8" do
+  describe "HSL and RGB888 conversions" do
+    test "converts from HSL to RGB888" do
       for %{hsl: [h, s, l], rgb: [r, g, b]} <- color_table() do
-        assert RGB8.new(r, g, b) == Chameleon.convert(HSL.new(h, s, l), Color.RGB8)
+        assert RGB888.new(r, g, b) == Chameleon.convert(HSL.new(h, s, l), Color.RGB888)
       end
     end
 
     test "converts from CMYK to HSL" do
       for %{hsl: [h, s, l], rgb: [r, g, b]} <- color_table() do
-        assert HSL.new(h, s, l) == Chameleon.convert(RGB8.new(r, g, b), Color.HSL)
+        assert HSL.new(h, s, l) == Chameleon.convert(RGB888.new(r, g, b), Color.HSL)
       end
     end
   end
 
-  describe "HSV and RGB8 conversions" do
-    test "converts from HSV to RGB8" do
+  describe "HSV and RGB888 conversions" do
+    test "converts from HSV to RGB888" do
       for %{hsv: [h, s, v], rgb: [r, g, b]} <- color_table() do
-        assert RGB8.new(r, g, b) == Chameleon.convert(HSV.new(h, s, v), Color.RGB8)
+        assert RGB888.new(r, g, b) == Chameleon.convert(HSV.new(h, s, v), Color.RGB888)
       end
     end
 
-    test "converts from RGB8 to HSV" do
+    test "converts from RGB888 to HSV" do
       for %{hsv: [h, s, v], rgb: [r, g, b]} <- color_table() do
-        assert HSV.new(h, s, v) == Chameleon.convert(RGB8.new(r, g, b), Color.HSV)
+        assert HSV.new(h, s, v) == Chameleon.convert(RGB888.new(r, g, b), Color.HSV)
       end
     end
   end
 
-  describe "Keyword and RGB8 conversions" do
-    test "converts from Keyword to RGB8" do
+  describe "Keyword and RGB888 conversions" do
+    test "converts from Keyword to RGB888" do
       for %{keyword: keyword, rgb: [r, g, b]} <- color_table() do
-        assert RGB8.new(r, g, b) == Chameleon.convert(Keyword.new(keyword), Color.RGB8)
+        assert RGB888.new(r, g, b) == Chameleon.convert(Keyword.new(keyword), Color.RGB888)
       end
     end
 
     test "converts from CMYK to Keyword" do
       for %{keyword: keyword,  rgb: [r, g, b]} <- color_table() do
-        assert Keyword.new(keyword) == Chameleon.convert(RGB8.new(r, g, b), Color.Keyword)
+        assert Keyword.new(keyword) == Chameleon.convert(RGB888.new(r, g, b), Color.Keyword)
       end
     end
   end
@@ -79,13 +79,13 @@ defmodule RGB8Test do
   describe "Pantone and CMYK conversions" do
     test "converts from Pantone to CMYK" do
       for %{pantone: pantone,  rgb: [r, g, b]} <- color_table(), not is_nil(pantone) do
-        assert RGB8.new(r, g, b) == Chameleon.convert(Pantone.new(pantone), Color.RGB8)
+        assert RGB888.new(r, g, b) == Chameleon.convert(Pantone.new(pantone), Color.RGB888)
       end
     end
 
     test "converts from CMYK to Pantone" do
       for %{pantone: pantone,  rgb: [r, g, b]} <- color_table(), not is_nil(pantone) do
-        assert Pantone.new(pantone) == Chameleon.convert(RGB8.new(r, g, b), Color.Pantone)
+        assert Pantone.new(pantone) == Chameleon.convert(RGB888.new(r, g, b), Color.Pantone)
       end
     end
   end

--- a/test/rgb8_test.exs
+++ b/test/rgb8_test.exs
@@ -1,0 +1,92 @@
+defmodule RGB8Test do
+  use ExUnit.Case
+  use ChameleonTest.Case
+
+  alias Chameleon.{Color, Hex, HSL, HSV, Keyword, Pantone, RGB, RGB8}
+
+  doctest Chameleon.RGB8
+
+  describe "RGB and RGB8 conversions" do
+    test "converts from RGB to RGB8" do
+      for %{rgb: [r, g, b]} <- color_table() do
+        assert RGB8.new(r, g, b) == Chameleon.convert(RGB.new(r, g, b), Color.RGB8)
+      end
+    end
+
+    test "converts from RGB8 to RGB" do
+      for %{rgb: [r, g, b]} <- color_table() do
+        assert RGB.new(r, g, b) == Chameleon.convert(RGB8.new(r, g, b), Color.RGB)
+      end
+    end
+  end
+
+  describe "Hex and RGB8 conversions" do
+    test "converts from HEX to RGB8" do
+      for %{hex: hex, rgb: [r, g, b]} <- color_table() do
+        assert RGB8.new(r, g, b) == Chameleon.convert(Hex.new(hex), Color.RGB8)
+      end
+    end
+
+    test "converts from RGB8 to HEX" do
+      for %{hex: hex, rgb: [r, g, b]} <- color_table() do
+        assert Hex.new(hex) == Chameleon.convert(RGB8.new(r, g, b), Color.Hex)
+      end
+    end
+  end
+
+  describe "HSL and RGB8 conversions" do
+    test "converts from HSL to RGB8" do
+      for %{hsl: [h, s, l], rgb: [r, g, b]} <- color_table() do
+        assert RGB8.new(r, g, b) == Chameleon.convert(HSL.new(h, s, l), Color.RGB8)
+      end
+    end
+
+    test "converts from CMYK to HSL" do
+      for %{hsl: [h, s, l], rgb: [r, g, b]} <- color_table() do
+        assert HSL.new(h, s, l) == Chameleon.convert(RGB8.new(r, g, b), Color.HSL)
+      end
+    end
+  end
+
+  describe "HSV and RGB8 conversions" do
+    test "converts from HSV to RGB8" do
+      for %{hsv: [h, s, v], rgb: [r, g, b]} <- color_table() do
+        assert RGB8.new(r, g, b) == Chameleon.convert(HSV.new(h, s, v), Color.RGB8)
+      end
+    end
+
+    test "converts from RGB8 to HSV" do
+      for %{hsv: [h, s, v], rgb: [r, g, b]} <- color_table() do
+        assert HSV.new(h, s, v) == Chameleon.convert(RGB8.new(r, g, b), Color.HSV)
+      end
+    end
+  end
+
+  describe "Keyword and RGB8 conversions" do
+    test "converts from Keyword to RGB8" do
+      for %{keyword: keyword, rgb: [r, g, b]} <- color_table() do
+        assert RGB8.new(r, g, b) == Chameleon.convert(Keyword.new(keyword), Color.RGB8)
+      end
+    end
+
+    test "converts from CMYK to Keyword" do
+      for %{keyword: keyword,  rgb: [r, g, b]} <- color_table() do
+        assert Keyword.new(keyword) == Chameleon.convert(RGB8.new(r, g, b), Color.Keyword)
+      end
+    end
+  end
+
+  describe "Pantone and CMYK conversions" do
+    test "converts from Pantone to CMYK" do
+      for %{pantone: pantone,  rgb: [r, g, b]} <- color_table(), not is_nil(pantone) do
+        assert RGB8.new(r, g, b) == Chameleon.convert(Pantone.new(pantone), Color.RGB8)
+      end
+    end
+
+    test "converts from CMYK to Pantone" do
+      for %{pantone: pantone,  rgb: [r, g, b]} <- color_table(), not is_nil(pantone) do
+        assert Pantone.new(pantone) == Chameleon.convert(RGB8.new(r, g, b), Color.Pantone)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #14 

Supports the use of the RGB888 struct, which is essentially the same as RGB, but is a common way to reference that color model