### PR TITLE
Fix RGB to HSV hue conversion

### DIFF
--- a/lib/chameleon/rgb.ex
+++ b/lib/chameleon/rgb.ex
@@ -182,7 +182,7 @@ defmodule Chameleon.RGB do
   end
 
   defp hue(delta, _, _, _, _) when delta <= 0, do: 0
-  defp hue(delta, r, r, g, b), do: 60 * rem(round((g - b) / delta), 6)
+  defp hue(delta, r, r, g, b), do: 60 * rem(round((g - b) / delta * 100), 600) / 100
   defp hue(delta, g, r, g, b), do: 60 * ((b - r) / delta + 2)
   defp hue(delta, b, r, g, b), do: 60 * ((r - g) / delta + 4)
 

--- a/lib/chameleon/rgb.ex
+++ b/lib/chameleon/rgb.ex
@@ -182,7 +182,7 @@ defmodule Chameleon.RGB do
   end
 
   defp hue(delta, _, _, _, _) when delta <= 0, do: 0
-  defp hue(delta, r, r, g, b), do: 60 * rem(round((g - b) / delta * 100), 600) / 100
+  defp hue(delta, r, r, g, b), do: 60 * :math.fmod((g - b) / delta, 6)
   defp hue(delta, g, r, g, b), do: 60 * ((b - r) / delta + 2)
   defp hue(delta, b, r, g, b), do: 60 * ((r - g) / delta + 4)
 

--- a/test/hsl_test.exs
+++ b/test/hsl_test.exs
@@ -14,7 +14,7 @@ defmodule HSLTest do
     end
 
     test "verifies RGB to HSL conversions" do
-      assert HSL.new(99, 91, 57) ==  Chameleon.convert(RGB.new(115, 245, 46), Color.HSL)
+      assert HSL.new(99, 91, 57) == Chameleon.convert(RGB.new(115, 245, 46), Color.HSL)
       assert HSL.new(100, 32, 64) == Chameleon.convert(RGB.new(154, 193, 134), Color.HSL)
       assert HSL.new(255, 32, 64) == Chameleon.convert(RGB.new(149, 134, 193), Color.HSL)
     end

--- a/test/hsv_test.exs
+++ b/test/hsv_test.exs
@@ -21,7 +21,10 @@ defmodule HSVTest do
       {RGB.new(0, 128, 0), HSV.new(120, 100, 50)},
       {RGB.new(128, 0, 128), HSV.new(300, 100, 50)},
       {RGB.new(0, 128, 128), HSV.new(180, 100, 50)},
-      {RGB.new(0, 0, 128), HSV.new(240, 100, 50)}
+      {RGB.new(0, 0, 128), HSV.new(240, 100, 50)},
+      {RGB.new(181, 33, 75), HSV.new(343, 82, 71)},
+      {RGB.new(79, 36, 74), HSV.new(307, 54, 31)},
+      {RGB.new(79, 58, 36), HSV.new(31, 54, 31)}
     ]
   end
 

--- a/test/rgb_test.exs
+++ b/test/rgb_test.exs
@@ -55,10 +55,22 @@ defmodule RGBTest do
       end
     end
 
+    test "verifies HSV to RGB conversions" do
+      assert RGB.new(181, 33, 75) == Chameleon.convert(HSV.new(343, 82, 71), Color.RGB)
+      assert RGB.new(79, 36, 74) == Chameleon.convert(HSV.new(307, 54, 31), Color.RGB)
+      assert RGB.new(79, 58, 36) == Chameleon.convert(HSV.new(31, 54, 31), Color.RGB)
+    end
+
     test "converts from RGB to HSV" do
       for %{hsv: [h, s, v], rgb: [r, g, b]} <- color_table() do
         assert HSV.new(h, s, v) == Chameleon.convert(RGB.new(r, g, b), Color.HSV)
       end
+    end
+
+    test "verifies RGB to HSV conversions" do
+      assert HSV.new(343, 82, 71) == Chameleon.convert(RGB.new(181, 33, 75), Color.HSV)
+      assert HSV.new(307, 54, 31) == Chameleon.convert(RGB.new(79, 36, 74), Color.HSV)
+      assert HSV.new(31, 54, 31) == Chameleon.convert(RGB.new(79, 58, 36), Color.HSV)
     end
   end
 


### PR DESCRIPTION
This addresses an issue with hue calculation for RGB to HSV conversion when `c_max` is equal to `r`. At first glance, the calculation looks correct, but due to the integer requirement of `rem/2` there is a loss of precision and subsequently erroneous conversion. This approach addresses the issue using Erlang's `:math.fmod` for float precision on the modulo operation. Below are three samples for comparison.

**Current**
```elixir
iex> RGB.new(181, 33, 75) |> Chameleon.convert(HSV)
%Chameleon.HSV{h: 0, s: 82, v: 71}

iex> RGB.new(79, 36, 74) |> Chameleon.convert(HSV) 
%Chameleon.HSV{h: 300, s: 54, v: 31}

iex> RGB.new(79, 58, 36) |> Chameleon.convert(HSV)
%Chameleon.HSV{h: 60, s: 54, v: 31}
```

**Updated**
```elixir
iex> RGB.new(181, 33, 75) |> Chameleon.convert(HSV)
%Chameleon.HSV{h: 343, s: 82, v: 71}

iex> RGB.new(79, 36, 74) |> Chameleon.convert(HSV)
%Chameleon.HSV{h: 307, s: 54, v: 31}

iex> RGB.new(79, 58, 36) |> Chameleon.convert(HSV)
%Chameleon.HSV{h: 31, s: 54, v: 31}
```